### PR TITLE
Fixed request filenames from es

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -41,6 +41,7 @@ import org.apache.tika.metadata.Metadata;
 import java.io.*;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -51,6 +52,8 @@ import static fr.pilato.elasticsearch.crawler.fs.TikaInstance.tika;
  * @author dadoonet (David Pilato)
  */
 public class FsCrawlerImpl {
+
+    public static final int REQUEST_SIZE = 10000;
 
     public static final class PROTOCOL {
         public static final String LOCAL = "local";
@@ -301,6 +304,7 @@ public class FsCrawlerImpl {
             path.open();
 
             try {
+
                 final Collection<FileAbstractModel> children = path.getFiles(filepath);
                 Collection<String> fsFiles = new ArrayList<>();
                 Collection<String> fsFolders = new ArrayList<>();
@@ -340,52 +344,57 @@ public class FsCrawlerImpl {
                     }
                 }
 
-                // TODO Optimize
-                // if (path.isDirectory() && path.lastModified() > lastScanDate
-                // && lastScanDate != 0) {
-
                 if (fsSettings.getFs().isRemoveDeleted()) {
-                    logger.debug("Looking for removed files in [{}]...", filepath);
                     Collection<String> esFiles = getFileDirectory(filepath);
-
-                    // for the delete files
-                    for (String esfile : esFiles) {
-                        logger.trace("Checking file [{}]", esfile);
-
-                        if (FsCrawlerUtil.isIndexable(esfile, fsSettings.getFs().getIncludes(), fsSettings.getFs().getExcludes())
-                                && !fsFiles.contains(esfile)) {
-                            File file = new File(filepath, esfile);
-
-                            logger.trace("Removing file [{}] in elasticsearch", esfile);
-                            esDelete(fsSettings.getElasticsearch().getIndex(), fsSettings.getElasticsearch().getType(),
-                                    SignTool.sign(file.getAbsolutePath()));
-                            stats.removeFile();
-                        }
-                    }
-
-                    logger.debug("Looking for removed directories in [{}]...", filepath);
-                    Collection<String> esFolders = getFolderDirectory(filepath);
-
-                    // for the delete folder
-                    for (String esfolder : esFolders) {
-                        if (FsCrawlerUtil.isIndexable(esfolder, fsSettings.getFs().getIncludes(), fsSettings.getFs().getExcludes())) {
-                            logger.trace("Checking directory [{}]", esfolder);
-                            if (!fsFolders.contains(esfolder)) {
-                                logger.trace("Removing recursively directory [{}] in elasticsearch", esfolder);
-                                removeEsDirectoryRecursively(filepath, esfolder);
-                            }
-                        }
-                    }
+                    removeDeletedFilesFromElasticsearch(filepath, esFiles, fsFiles);
+                    removeDeletedDirectoriesFromElasticsearch(filepath, fsFolders);
                 }
+
             } finally {
                 path.close();
             }
         }
 
+        private void removeDeletedDirectoriesFromElasticsearch(String filepath, Collection<String> fsFolders) throws Exception {
+            logger.debug("Looking for removed directories in [{}]...", filepath);
+            Collection<String> esFolders = getFolderDirectory(filepath);
+
+            // for the delete folder
+            for (String esfolder : esFolders) {
+                if (FsCrawlerUtil.isIndexable(esfolder, fsSettings.getFs().getIncludes(), fsSettings.getFs().getExcludes())) {
+                    logger.trace("Checking directory [{}]", esfolder);
+                    if (!fsFolders.contains(esfolder)) {
+                        logger.trace("Removing recursively directory [{}] in elasticsearch", esfolder);
+                        removeEsDirectoryRecursively(filepath, esfolder);
+                    }
+                }
+            }
+        }
+
+        private void removeDeletedFilesFromElasticsearch(String filepath, Collection<String> esFiles, Collection<String> fsFiles) throws NoSuchAlgorithmException {
+            logger.debug("Looking for removed files in [{}]...", filepath);
+
+
+            // for the delete files
+            for (String esfile : esFiles) {
+                logger.trace("Checking file [{}]", esfile);
+
+                if (FsCrawlerUtil.isIndexable(esfile, fsSettings.getFs().getIncludes(), fsSettings.getFs().getExcludes())
+                        && !fsFiles.contains(esfile)) {
+                    File file = new File(filepath, esfile);
+
+                    logger.trace("Removing file [{}] in elasticsearch", esfile);
+                    esDelete(fsSettings.getElasticsearch().getIndex(), fsSettings.getElasticsearch().getType(),
+                            SignTool.sign(file.getAbsolutePath()));
+                    stats.removeFile();
+                }
+            }
+        }
+
         // TODO Optimize it. We can probably use a search for a big array of filenames instead of
         // Searching fo 50000 files (which is somehow limited).
-        private Collection<String> getFileDirectory(String path)
-                throws Exception {
+        // --> changed to 10000 which is the max. Higher values results to a default of 10 (pagination)
+        private Collection<String> getFileDirectory(String path) throws Exception {
             Collection<String> files = new ArrayList<>();
 
             // If the crawler is being closed, we return
@@ -398,35 +407,47 @@ public class FsCrawlerImpl {
                     fsSettings.getElasticsearch().getIndex(),
                     fsSettings.getElasticsearch().getType(),
                     PATH_ENCODED + ":" + SignTool.sign(path),
-                    50000, // TODO: WHAT? DID I REALLY WROTE THAT? :p
+                    REQUEST_SIZE,
                     FILE_FILENAME
             );
 
-            logger.trace("Response [{} hits]", response.getHits() != null ? response.getHits().getTotal() : 0);
-            if (response.getHits() != null && response.getHits().getHits() != null) {
-                for (SearchResponse.Hit hit : response.getHits().getHits()) {
-                    String name;
-                    if (hit.getSource() != null
-                            && hit.getSource().get(FsCrawlerUtil.Doc.FILE) != null
-                            && ((Map<String, Object>) hit.getSource().get(FsCrawlerUtil.Doc.FILE)).get(FsCrawlerUtil.Doc.File.FILENAME) != null) {
-                        name = ((Map<String, Object>) hit.getSource().get(FsCrawlerUtil.Doc.FILE)).get(FsCrawlerUtil.Doc.File.FILENAME).toString();
-                    } else if (hit.getFields() != null
-                            && hit.getFields().get(FsCrawlerUtil.Doc.FILE) != null
-                            && ((Map<String, Object>) hit.getFields().get(FsCrawlerUtil.Doc.FILE)).get(FsCrawlerUtil.Doc.File.FILENAME) != null) {
-                        name = ((Map<String, Object>) hit.getFields().get(FsCrawlerUtil.Doc.FILE)).get(FsCrawlerUtil.Doc.File.FILENAME).toString();
-                    } else {
-                        // Houston, we have a problem ! We can't get the old files from ES
-                        logger.warn("Can't find in _source nor fields the existing filenames in path [{}]. " +
-                                "Please enable _source or store field [{}]", path, FILE_FILENAME);
-                        throw new RuntimeException("Mapping is incorrect: please enable _source or store field [" +
-                                FILE_FILENAME + "].");
+            if (response.getHits() != null) {
+                logger.trace("Response [{} hits]", response.getHits().getTotal());
+
+                if (response.getHits().getHits() != null) {
+                    List<SearchResponse.Hit> hits = response.getHits().getHits();
+
+                    for (SearchResponse.Hit hit : hits) {
+                        String name;
+                        if (hit.getSource() != null && hit.getSource().get(FILE_FILENAME) != null) {
+                            name = getName(hit.getSource().get(FILE_FILENAME));
+
+                        } else if (hit.getFields() != null && hit.getFields().get(FILE_FILENAME) != null) {
+                            name = getName(hit.getFields().get(FILE_FILENAME));
+
+                        } else {
+                            // Houston, we have a problem ! We can't get the old files from ES
+                            logger.warn("Can't find in _source nor fields the existing filenames in path [{}]. " +
+                                    "Please enable _source or store field [{}]", path, FILE_FILENAME);
+                            throw new RuntimeException("Mapping is incorrect: please enable _source or store field [" +
+                                    FILE_FILENAME + "].");
+                        }
+
+                        files.add(name);
                     }
-                    files.add(name);
                 }
             }
 
             return files;
+        }
 
+        private String getName(Object nameObject) {
+
+            if(nameObject instanceof List){
+                return String.valueOf (((List) nameObject).get(0));
+            }
+
+            throw new RuntimeException("search result, file.name not of type List<String>");
         }
 
         private Collection<String> getFolderDirectory(String path)
@@ -442,7 +463,7 @@ public class FsCrawlerImpl {
                     fsSettings.getElasticsearch().getIndex(),
                     FsCrawlerUtil.INDEX_TYPE_FOLDER,
                     PATH_ENCODED + ":" + SignTool.sign(path),
-                    50000, // TODO: WHAT? DID I REALLY WROTE THAT? :p
+                    REQUEST_SIZE, // TODO: WHAT? DID I REALLY WROTE THAT? :p
                     null
             );
 

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -234,10 +234,10 @@ public class ElasticsearchClient {
 
         logger.trace("going to send a bulk");
 
-        if(logger.isInfoEnabled()){
+        if(logger.isDebugEnabled()){
             int bulkSize = bulkRequest.getRequests() != null ? bulkRequest.getRequests().size() : 0;
-            logger.info("sending {} documents to es...", bulkSize);
-            logger.info("request:" + System.getProperty("line.separator") + sbf.toString());
+            logger.debug("bulk request, sending {} documents to es...", bulkSize);
+            logger.debug("request:" + System.getProperty("line.separator") + sbf.toString());
         }
 
         GenericUrl genericUrl = buildUrl(node);

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -234,6 +234,12 @@ public class ElasticsearchClient {
 
         logger.trace("going to send a bulk");
 
+        if(logger.isInfoEnabled()){
+            int bulkSize = bulkRequest.getRequests() != null ? bulkRequest.getRequests().size() : 0;
+            logger.info("sending {} documents to es...", bulkSize);
+            logger.info("request:" + System.getProperty("line.separator") + sbf.toString());
+        }
+
         GenericUrl genericUrl = buildUrl(node);
         genericUrl.appendRawPath("/_bulk");
         HttpRequest request = requestFactory.buildPostRequest(genericUrl,

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/SearchRequest.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/SearchRequest.java
@@ -19,11 +19,18 @@
 
 package fr.pilato.elasticsearch.crawler.fs.client;
 
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
 import java.util.Arrays;
 
-public class SearchRequest {
+public class SearchRequest  extends GenericJson {
     private final String query;
+
+    @Key
     private final String[] fields;
+
+    @Key
     private final Integer size;
 
     public static Builder builder() {

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/SearchResponse.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/SearchResponse.java
@@ -75,7 +75,7 @@ public class SearchResponse extends GenericJson {
 
         @Key("_source")
         private Map<String, Object> source;
-        @Key("_fields")
+        @Key("fields")
         private Map<String, Object> fields;
 
         public Map<String, Object> getSource() {

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/AbstractFSCrawlerTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/AbstractFSCrawlerTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractFSCrawlerTest {
     }
 
     public static boolean awaitBusy(BooleanSupplier breakSupplier) throws InterruptedException {
-        return awaitBusy(breakSupplier, 10, TimeUnit.SECONDS);
+        return awaitBusy(breakSupplier, 5, TimeUnit.SECONDS);
     }
 
     // After 1s, we stop growing the sleep interval exponentially and just sleep 1s until maxWaitTime

--- a/src/test/java/fr/pilato/elasticsearch/crawler/integration/FsCrawlerImplAllParametersTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/integration/FsCrawlerImplAllParametersTest.java
@@ -482,7 +482,7 @@ public class FsCrawlerImplAllParametersTest extends AbstractMonoNodeITest {
         logger.info(" ---> Removing file deleted_roottxtfile.txt");
         Files.delete(currentTestResourceDir.resolve("deleted_roottxtfile.txt"));
 
-        // We expect to have two files
+        // We expect to have one file
         countTestHelper(getCrawlerName(), null, 1, currentTestResourceDir);
     }
 


### PR DESCRIPTION
Requesting filenames from es doesn't work. The main reason is that the json request body will not be send within the request. Fixing this bug results in some further bugs...
